### PR TITLE
Fix various PHP warnings

### DIFF
--- a/src/SalesLayer-Conn.php
+++ b/src/SalesLayer-Conn.php
@@ -101,7 +101,7 @@ class SalesLayer_Conn {
      *
      */
 
-    private function __has_system_requirements () {
+    private static function __has_system_requirements () {
 
         if (!extension_loaded('curl')) {
 
@@ -120,7 +120,7 @@ class SalesLayer_Conn {
      * @return string
      */
 
-    private function __get_api_url ($last_update=false) {
+    private static function __get_api_url ($last_update=false) {
 
         if (self::$__secretKey != null) {
 
@@ -150,7 +150,7 @@ class SalesLayer_Conn {
      * 
      */
 
-    private function __clean_error () {
+    private static function __clean_error () {
 
         self::$response_error         = 0;
         self::$response_error_message = '';

--- a/src/SalesLayer-Updater.php
+++ b/src/SalesLayer-Updater.php
@@ -194,7 +194,7 @@ class SalesLayer_Updater extends SalesLayer_Conn {
      *
      */
 
-    private function __set_database_credentials ($database=null, $username=null, $password=null, $hostname=null) {
+    private static function __set_database_credentials ($database=null, $username=null, $password=null, $hostname=null) {
 
         if ($database!=null) { self::$database = $database; }
         if ($database!=null) { self::$username = $username; }
@@ -547,7 +547,9 @@ class SalesLayer_Updater extends SalesLayer_Conn {
                 } else { return self::$database_config; }
             }
         }
-
+        
+        $config = isset($config) ? $config : null;
+        
         return self::$database_config = $config;
     }
 
@@ -1123,7 +1125,7 @@ class SalesLayer_Updater extends SalesLayer_Conn {
 
                     foreach ($schema as $field=>$info) {
 
-                        if ($info['has_multilingual']) {
+                        if (!empty($info['has_multilingual'])) {
 
                             $fields_conn[$info['name'].'_'.$info['language']]=$field;
 


### PR DESCRIPTION
These changes stop various PHP warnings about calling a non-static method from a static method and a couple of checks to stop 'undefined variable' warnings.
