### PR TITLE
Fixed an issue on line 1255 of SalesLayer-Updater.php

### DIFF
--- a/src/SalesLayer-Updater.php
+++ b/src/SalesLayer-Updater.php
@@ -1252,6 +1252,10 @@ class SalesLayer_Updater extends SalesLayer_Conn {
 
                             } else if (isset($fields_conn[$field])) {
 
+                                if(is_array($data)) {
+                                    $newdata = implode(',', $data);
+                                    $data = $newdata;
+                                }
                                 $fields.=(($fields) ? ', ' : '')."`{$fields_conn[$field]}` = '".  addslashes($data)."'";
                             }
                         }


### PR DESCRIPTION
Fixed an issue in which, when $__group_multicategory is set to TRUE you receive the following error:

Warning: addslashes() expects parameter 1 to be string, array given in /<LOCATION>/sales-layer-api/src/SalesLayer-Updater.php on line 1255.
This fix implodes the given array back into a string to be used in the unedited line of code now on line 1259.
