### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,9 @@
     "autoload": {
         "classmap": [
         	"src/SalesLayer-Conn.php",
-        	"src/SalesLayer-Updater.php"
+        	"src/SalesLayer-Updater.php",
+        	"src/lib/class.DBPDO.php",
+        	"src/lib/class.MySQL.php"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "saleslayer/saleslayer-php-sdk",
+    "description": "SalesLayer PHP SDK",
+    "require": {
+        "php": ">=5.0.0"
+    },
+    "autoload": {
+        "classmap": [
+        	"src/SalesLayer-Conn.php",
+        	"src/SalesLayer-Updater.php"
+        ]
+    }
+}


### PR DESCRIPTION
Add a composer.json file for packagist/composer support.
I'd love it if you guys could add SalesLayer PHP SDK to [packagist](https://packagist.org/) so it can be used through composer.
This composer.json file _should_ be correct, but will need testing, as I can't do that without adding it to packagist myself, which I shouldn't really do.

_Ideally_ you'd add PSR-4 namespacing to your classes (or PSR-0 at least) to make it autoload nicely, but classmapping should be a workable stopgap. This would of course mean a minimum requirement of PHP 5.3, but people should really be using **at least** 5.5 anyway...
