### PR TITLE
MySQL 5.7+ changes and making catalogue_id in _products table a varchar when group multicategory is true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+/.idea
+/vendor
+/node_modules
+.DS_Store
+.DS_Store?
+.env
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/src/SalesLayer-Conn.php
+++ b/src/SalesLayer-Conn.php
@@ -34,7 +34,7 @@ class SalesLayer_Conn {
     private $__secretKey                 = null;
     private $__keyCypher                 = 'sha256'; // <-- or 'sha1'
 
-    private $__group_multicategory       = false;
+    protected $__group_multicategory     = false;
 
     public  $data_returned               = null;
     public  $response_api_version        = null;

--- a/src/SalesLayer-Updater.php
+++ b/src/SalesLayer-Updater.php
@@ -61,13 +61,13 @@ class SalesLayer_Updater extends SalesLayer_Conn {
 
     private $database_field_types_charset = array(
 
-        'text'      =>'CHARACTER SET {collation} NOT NULL',
-        'mediumtext'=>'CHARACTER SET {collation} NOT NULL',
-        'bool'      =>'NOT NULL',
-        'double'    =>'NOT NULL',
-        'datetime'  =>'NOT NULL',
-        'int'       =>'NOT NULL',
-        'bigint'    =>'NOT NULL',
+        'text'      =>'CHARACTER SET {collation}',
+        'mediumtext'=>'CHARACTER SET {collation}',
+        'bool'      =>'',
+        'double'    =>'',
+        'datetime'  =>'',
+        'int'       =>'',
+        'bigint'    =>'',
     );
 
     /**
@@ -273,19 +273,19 @@ class SalesLayer_Updater extends SalesLayer_Conn {
             if (!in_array($config_table, $tables)) {
 
                 $SQL = $this->__fix_collation("CREATE TABLE IF NOT EXISTS `$config_table` (".
-                                              '`cnf_id` int(11) NOT NULL AUTO_INCREMENT, '.
-                                              '`conn_code` varchar(32) NOT NULL, '.
-                                              '`conn_secret` varchar(32) NOT NULL, '.
-                                              '`comp_id` int(11) NOT NULL, '.
-                                              '`last_update` int DEFAULT NULL, '.
-                                              '`default_language` varchar(6) NOT NULL, '.
-                                              '`languages` varchar(512) NOT NULL, '.
-                                              '`conn_schema` mediumtext CHARACTER SET {collation} NOT NULL, '.
-                                              '`data_schema` mediumtext CHARACTER SET {collation} NOT NULL, '.
-                                              '`conn_extra` mediumtext CHARACTER SET {collation} NOT NULL, '.
-                                              '`updater_version` varchar(10) NOT NULL, '.
-                                              'PRIMARY KEY (`cnf_id`)'.
-                                              ') ENGINE='.$this->table_engine.' ROW_FORMAT='.$this->table_row_format.' DEFAULT CHARSET={collation} AUTO_INCREMENT=1');
+                    '`cnf_id` int(11) NOT NULL AUTO_INCREMENT, '.
+                    '`conn_code` varchar(32) NOT NULL, '.
+                    '`conn_secret` varchar(32) NOT NULL, '.
+                    '`comp_id` int(11) NOT NULL, '.
+                    '`last_update` int, '.
+                    '`default_language` varchar(6) NOT NULL, '.
+                    '`languages` varchar(512) NOT NULL, '.
+                    '`conn_schema` mediumtext CHARACTER SET {collation} NOT NULL, '.
+                    '`data_schema` mediumtext CHARACTER SET {collation} NOT NULL, '.
+                    '`conn_extra` mediumtext CHARACTER SET {collation}, '.
+                    '`updater_version` varchar(10) NOT NULL, '.
+                    'PRIMARY KEY (`cnf_id`)'.
+                    ') ENGINE='.$this->table_engine.' ROW_FORMAT='.$this->table_row_format.' DEFAULT CHARSET={collation} AUTO_INCREMENT=1');
 
                 if ($this->DB->execute($this->SQL_list[] = $SQL)) {
 
@@ -1402,7 +1402,7 @@ class SalesLayer_Updater extends SalesLayer_Conn {
 
                                         } else {
 
-                                            $fields .= ($fields ? ', ' : '')."`{$fields_conn[$d_field]}` = '".  addslashes($value)."'";
+                                            $fields .= ($fields ? ', ' : '')."`{$fields_conn[$d_field]}` = ".  (empty($value) ? 'null' : "'".addslashes($value)."'");
                                         }
                                     }
                                 }


### PR DESCRIPTION
Applied the MySQL 5.7+ changes from earlier bug report, as this is now being used on a lot of servers.

Also, making catalogue_id in _products table a varchar when group multicategory is true, because it's comma separated.